### PR TITLE
Remove superfluous call to DateTime::getTimestamp

### DIFF
--- a/src/SimpleCache/CacheProvider.php
+++ b/src/SimpleCache/CacheProvider.php
@@ -166,7 +166,6 @@ abstract class CacheProvider implements CacheInterface
         } elseif ($ttl instanceof DateInterval) {
             $datetimeObj = new DateTime();
             $datetimeObj->add($ttl);
-            $datetimeObj->getTimestamp();
 
             if ($now - $timestamp < $datetimeObj->getTimestamp()) {
                 return false;


### PR DESCRIPTION
Hello, 

The attached commit fixes a little inefficiency & code-smell in `CacheProvider.php`. 
A call to `DateTime::getTimestamp` was made but the result was not used. Since `getTimestamp` has no side-effect, that makes the call useless.
